### PR TITLE
Update subtype names for old LP/BP/HP filters

### DIFF
--- a/examples/filter_plot_tool/filter_plot_tool.cpp
+++ b/examples/filter_plot_tool/filter_plot_tool.cpp
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
     if (argc > 3)
         filterType = static_cast<sst::filters::FilterType>(std::atoi(argv[3]));
 
-    auto filterSubType = sst::filters::FilterSubType::st_SVF;
+    auto filterSubType = sst::filters::FilterSubType::st_Standard;
     if (argc > 4)
         filterSubType = static_cast<sst::filters::FilterSubType>(std::atoi(argv[4]));
 

--- a/examples/filters_example_plugin/FiltersPluginEditor.cpp
+++ b/examples/filters_example_plugin/FiltersPluginEditor.cpp
@@ -125,13 +125,11 @@ void fillStringArrayWithFilterSubTypes(juce::StringArray &strArray,
     {
     case FilterType::fut_lp12:
     case FilterType::fut_lp24:
+    case FilterType::fut_bp12:
+    case FilterType::fut_bp24:
     case FilterType::fut_hp12:
     case FilterType::fut_hp24:
         fillArray(sst::filters::fut_def_subtypes);
-        break;
-    case FilterType::fut_bp12:
-    case FilterType::fut_bp24:
-        fillArray(sst::filters::fut_bp_subtypes);
         break;
     case FilterType::fut_notch12:
     case FilterType::fut_notch24:

--- a/include/sst/filters/FilterConfiguration.h
+++ b/include/sst/filters/FilterConfiguration.h
@@ -129,12 +129,6 @@ const char filter_menu_names[num_filter_types][32] = {
     */
 };
 
-const char fut_bp_subtypes[3][32] = {
-    "Clean",
-    "Driven",
-    "Smooth",
-};
-
 const char fut_notch_subtypes[2][32] = {
     "Standard",
     "Mild",
@@ -146,9 +140,9 @@ const char fut_comb_subtypes[2][64] = {
 };
 
 const char fut_def_subtypes[3][32] = {
-    "Clean",
+    "Standard",
     "Driven",
-    "Smooth",
+    "Clean",
 };
 
 const char fut_ldr_subtypes[4][32] = {
@@ -247,10 +241,10 @@ const int fut_subcount[num_filter_types] = {
 /** Sub-types for each filter are defined here */
 enum FilterSubType
 {
-    st_SVF = 0,    /**< Clean */
-    st_Rough = 1,  /**< Driven */
-    st_Smooth = 2, /**< Smooth */
-    st_Medium = 3, /**< (Unused) */
+    st_Standard = 0, /**< Standard (SVF) */
+    st_Driven = 1,   /**< Driven */
+    st_Clean = 2,    /**< Clean */
+    st_Medium = 3,   /**< (Unused) */
 
     st_Notch = 0,     /**< Standard */
     st_NotchMild = 1, /**< Mild */

--- a/include/sst/filters/QuadFilterUnit_Impl.h
+++ b/include/sst/filters/QuadFilterUnit_Impl.h
@@ -597,11 +597,11 @@ inline FilterUnitQFPtr GetQFPtrFilterUnit(FilterType type, FilterSubType subtype
     {
         switch (subtype)
         {
-        case st_SVF:
+        case st_Standard:
             return SVFLP12Aquad;
-        case st_Rough:
+        case st_Driven:
             return IIR12CFCquad;
-        case st_Smooth:
+        case st_Clean:
             return IIR12Bquad;
         default:
             break;
@@ -611,11 +611,11 @@ inline FilterUnitQFPtr GetQFPtrFilterUnit(FilterType type, FilterSubType subtype
     {
         switch (subtype)
         {
-        case st_SVF:
+        case st_Standard:
             return SVFLP24Aquad;
-        case st_Rough:
+        case st_Driven:
             return IIR24CFCquad;
-        case st_Smooth:
+        case st_Clean:
             return IIR24Bquad;
         default:
             break;
@@ -626,11 +626,11 @@ inline FilterUnitQFPtr GetQFPtrFilterUnit(FilterType type, FilterSubType subtype
     {
         switch (subtype)
         {
-        case st_SVF:
+        case st_Standard:
             return SVFHP12Aquad;
-        case st_Rough:
+        case st_Driven:
             return IIR12CFCquad;
-        case st_Smooth:
+        case st_Clean:
             return IIR12Bquad;
         default:
             break;
@@ -641,11 +641,11 @@ inline FilterUnitQFPtr GetQFPtrFilterUnit(FilterType type, FilterSubType subtype
     {
         switch (subtype)
         {
-        case st_SVF:
+        case st_Standard:
             return SVFHP24Aquad;
-        case st_Rough:
+        case st_Driven:
             return IIR24CFCquad;
-        case st_Smooth:
+        case st_Clean:
             return IIR24Bquad;
         default:
             break;
@@ -656,11 +656,11 @@ inline FilterUnitQFPtr GetQFPtrFilterUnit(FilterType type, FilterSubType subtype
     {
         switch (subtype)
         {
-        case st_SVF:
+        case st_Standard:
             return SVFBP12Aquad;
-        case st_Rough:
+        case st_Driven:
             return IIR12CFCquad;
-        case st_Smooth:
+        case st_Clean:
             return IIR12Bquad;
         default:
             break;
@@ -671,11 +671,11 @@ inline FilterUnitQFPtr GetQFPtrFilterUnit(FilterType type, FilterSubType subtype
     {
         switch (subtype)
         {
-        case st_SVF:
+        case st_Standard:
             return SVFBP24Aquad;
-        case st_Rough:
+        case st_Driven:
             return IIR24CFCquad;
-        case st_Smooth:
+        case st_Clean:
             return IIR24Bquad;
         default:
             break;

--- a/tests/BasicFiltersTest.cpp
+++ b/tests/BasicFiltersTest.cpp
@@ -7,91 +7,91 @@ TEST_CASE("Basic Filters")
     SECTION("LP_12")
     {
         runTest({FilterType::fut_lp12,
-                 FilterSubType::st_SVF,
+                 FilterSubType::st_Standard,
                  {-8.02604f, -6.72912f, -3.8718f, -20.6177f, -53.7828f}});
 
         runTest({FilterType::fut_lp12,
-                 FilterSubType::st_Rough,
+                 FilterSubType::st_Driven,
                  {-4.52473f, -3.6442f, -2.13439f, -16.4384f, -49.3718f},
                  0.0f});
 
         runTest({FilterType::fut_lp12,
-                 FilterSubType::st_Smooth,
+                 FilterSubType::st_Clean,
                  {-3.62033f, -3.70258f, -6.10753f, -17.6442f, -53.1438f}});
     }
 
     SECTION("LP_24")
     {
         runTest({FilterType::fut_lp24,
-                 FilterSubType::st_SVF,
+                 FilterSubType::st_Standard,
                  {-7.79654f, -5.2026f, -1.93057f, -27.0258f, -50.9426f}});
 
         runTest({FilterType::fut_lp24,
-                 FilterSubType::st_Rough,
+                 FilterSubType::st_Driven,
                  {-6.51442f, -5.74044f, -6.61548f, -28.9689f, -54.0992f}});
 
         runTest({FilterType::fut_lp24,
-                 FilterSubType::st_Smooth,
+                 FilterSubType::st_Clean,
                  {-5.89545f, -10.7429f, -20.97f, -35.7356f, -60.1235f}});
     }
 
     SECTION("HP_12")
     {
         runTest({FilterType::fut_hp12,
-                 FilterSubType::st_SVF,
+                 FilterSubType::st_Standard,
                  {-35.8899f, -20.1651f, -3.91549f, -6.78058f, -8.34447f}});
 
         runTest({FilterType::fut_hp12,
-                 FilterSubType::st_Rough,
+                 FilterSubType::st_Driven,
                  {-31.4426f, -15.8495f, -1.84373f, -2.67782f, -4.16204f}});
 
         runTest({FilterType::fut_hp12,
-                 FilterSubType::st_Smooth,
+                 FilterSubType::st_Clean,
                  {-32.3916f, -17.1967f, -6.15529f, -3.55761f, -3.57168f}});
     }
 
     SECTION("HP_24")
     {
         runTest({FilterType::fut_hp24,
-                 FilterSubType::st_SVF,
+                 FilterSubType::st_Standard,
                  {-38.0661f, -27.0505f, -1.89886f, -5.27993f, -8.33136f}});
 
         runTest({FilterType::fut_hp24,
-                 FilterSubType::st_Rough,
+                 FilterSubType::st_Driven,
                  {-42.8669f, -28.9289f, -6.65685f, -4.0466f, -5.3227f}});
 
         runTest({FilterType::fut_hp24,
-                 FilterSubType::st_Smooth,
+                 FilterSubType::st_Clean,
                  {-51.1071f, -34.1528f, -16.2113f, -7.22786f, -4.15892f}});
     }
 
     SECTION("BP_12")
     {
         runTest({FilterType::fut_bp12,
-                 FilterSubType::st_SVF,
+                 FilterSubType::st_Standard,
                  {-22.9694f, -13.5409f, -3.81424f, -13.7711f, -34.7354f}});
 
         runTest({FilterType::fut_bp12,
-                 FilterSubType::st_Rough,
+                 FilterSubType::st_Driven,
                  {-12.6309f, -3.79841f, -0.00540512f, -4.4129f, -26.6096f}});
 
         runTest({FilterType::fut_bp12,
-                 FilterSubType::st_Smooth,
+                 FilterSubType::st_Clean,
                  {-18.7297f, -11.5658f, -9.04975f, -13.323f, -34.3029f}});
     }
 
     SECTION("BP_24")
     {
         runTest({FilterType::fut_bp24,
-                 FilterSubType::st_SVF,
+                 FilterSubType::st_Standard,
                  {-33.6982f, -18.0861f, -1.37863f, -18.7074f, -50.5816f}});
 
         runTest({FilterType::fut_bp24,
-                 FilterSubType::st_Rough,
+                 FilterSubType::st_Driven,
                  {-21.5631f, -6.61244f, -0.148954f, -6.07533f, -43.7467f}});
 
         runTest({FilterType::fut_bp24,
-                 FilterSubType::st_Smooth,
+                 FilterSubType::st_Clean,
                  {-39.4046f, -26.4753f, -21.4875f, -26.704f, -65.0009f}});
     }
 


### PR DESCRIPTION
Replace fut_bp_subtypes with fut_def_subtypes since they're identical