### PR TITLE
Add an optional Storage adapter to Biquad

### DIFF
--- a/include/sst/filters/BiquadFilter.h
+++ b/include/sst/filters/BiquadFilter.h
@@ -7,7 +7,29 @@
 
 namespace sst::filters::Biquad
 {
-template<typename TuningAndDBProvider, size_t BLOCK_SIZE>
+template<typename TuningAndDBProvider>
+struct DefaultTuningAndDBAdapter
+{
+    using ST = TuningAndDBProvider;
+    static inline float noteToPitchIgnoringTuning(ST *s, float n)
+    {
+        return s->note_to_pitch_ignoring_tuning(n);
+    }
+
+    static inline float dbToLinear(ST *s, float n)
+    {
+        return s->db_to_linear(n);
+    }
+
+    static inline double sampleRateInv(ST *s)
+    {
+        return s->dsamplerate_inv;
+    }
+
+};
+
+template<typename TuningAndDBProvider, size_t BLOCK_SIZE,
+    typename Adapter = DefaultTuningAndDBAdapter<TuningAndDBProvider>>
 struct alignas(16) BiquadFilter
 {
   private:
@@ -177,8 +199,8 @@ struct alignas(16) BiquadFilter
     double calc_omega(double scfreq)
     {
         return (2 * 3.14159265358979323846) * 440 *
-               storage->note_to_pitch_ignoring_tuning((float)(12.f * scfreq)) *
-               storage->dsamplerate_inv;
+               Adapter::noteToPitchIgnoringTuning(storage, (float)(12.f * scfreq)) *
+               Adapter::sampleRateInv(storage);
     }
     double calc_omega_from_Hz(double Hz)
     {
@@ -214,7 +236,7 @@ struct alignas(16) BiquadFilter
 
 inline double square(double x) { return x * x; }
 
-template<typename D, size_t BLOCK_SIZE> inline BiquadFilter<D, BLOCK_SIZE>::BiquadFilter(D *d) : storage(d)
+template<typename D, size_t BLOCK_SIZE, typename Adapter> inline BiquadFilter<D, BLOCK_SIZE, Adapter>::BiquadFilter(D *d) : storage(d)
 {
     reg0.d[0] = 0;
     reg1.d[0] = 0;
@@ -231,7 +253,7 @@ template<typename D, size_t BLOCK_SIZE> inline BiquadFilter<D, BLOCK_SIZE>::Biqu
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_LP(double omega, double Q)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_LP(double omega, double Q)
 {
     if (omega > M_PI)
         set_coef(1, 0, 0, 1, 0, 0);
@@ -244,7 +266,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_LP2B(double omega, double Q)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_LP2B(double omega, double Q)
 {
     if (omega > M_PI)
         set_coef(1, 0, 0, 1, 0, 0);
@@ -266,7 +288,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_HP(double omega, double Q)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_HP(double omega, double Q)
 {
     if (omega > M_PI)
         set_coef(1, 0, 0, 0, 0, 0);
@@ -280,7 +302,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_BP(double omega, double Q)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_BP(double omega, double Q)
 {
     double cosi = cos(omega), sinu = sin(omega), alpha = sinu / (2.0 * Q), b0 = alpha, b2 = -alpha,
            a0 = 1 + alpha, a1 = -2 * cosi, a2 = 1 - alpha;
@@ -288,7 +310,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     set_coef(a0, a1, a2, b0, 0, b2);
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_BP2A(double omega, double BW)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_BP2A(double omega, double BW)
 {
     double cosi = cos(omega), sinu = sin(omega), q = 1 / (0.02 + 30 * BW * BW),
            alpha = sinu / (2 * q), b0 = alpha, b2 = -alpha, a0 = 1 + alpha, a1 = -2 * cosi,
@@ -297,7 +319,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     set_coef(a0, a1, a2, b0, 0, b2);
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_PKA(double omega, double QQ)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_PKA(double omega, double QQ)
 {
     double cosi = cos(omega), sinu = sin(omega), reso = std::clamp(QQ, 0.0, 1.0),
            q = 0.1 + 10 * reso * reso, alpha = sinu / (2 * q), b0 = q * alpha, b2 = -q * alpha,
@@ -306,7 +328,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     set_coef(a0, a1, a2, b0, 0, b2);
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_NOTCH(double omega, double QQ)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_NOTCH(double omega, double QQ)
 {
     if (omega > M_PI)
         set_coef(1, 0, 0, 1, 0, 0);
@@ -320,11 +342,11 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_LP_with_BW(double omega, double BW) { coeff_LP(omega, 1 / BW); }
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_LP_with_BW(double omega, double BW) { coeff_LP(omega, 1 / BW); }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_HP_with_BW(double omega, double BW) { coeff_HP(omega, 1 / BW); }
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_HP_with_BW(double omega, double BW) { coeff_HP(omega, 1 / BW); }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_LPHPmorph(double omega, double Q, double morph)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_LPHPmorph(double omega, double Q, double morph)
 {
     double HP = std::clamp(morph, 0.0, 1.0), LP = 1 - HP, BP = LP * HP;
     HP *= HP;
@@ -336,7 +358,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     set_coef(a0, a1, a2, b0, b1, b2);
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_APF(double omega, double Q)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_APF(double omega, double Q)
 {
     if ((omega < 0.0) || (omega > M_PI))
         set_coef(1, 0, 0, 1, 0, 0);
@@ -349,12 +371,12 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_peakEQ(double omega, double BW, double gain)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_peakEQ(double omega, double BW, double gain)
 {
-    coeff_orfanidisEQ(omega, BW, storage->db_to_linear(gain), storage->db_to_linear(gain * 0.5), 1);
+    coeff_orfanidisEQ(omega, BW, Adapter::dbToLinear(storage, gain), Adapter::dbToLinear(storage, gain * 0.5), 1);
 }
 
-template <typename DT, size_t BLOCK_SIZE> inline void BiquadFilter<DT, BLOCK_SIZE>::coeff_orfanidisEQ(double omega, double BW, double G, double GB, double G0)
+template <typename DT, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<DT, BLOCK_SIZE, Adapter>::coeff_orfanidisEQ(double omega, double BW, double G, double GB, double G0)
 {
     // For the curious http://eceweb1.rutgers.edu/~orfanidi/ece521/hpeq.pdf appears to be the source
     // of this
@@ -410,12 +432,12 @@ template <typename DT, size_t BLOCK_SIZE> inline void BiquadFilter<DT, BLOCK_SIZ
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_same_as_last_time()
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_same_as_last_time()
 {
     // If you want to change interpolation then set dv = 0 here
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::coeff_instantize()
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::coeff_instantize()
 {
     a1.instantize();
     a2.instantize();
@@ -424,7 +446,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     b2.instantize();
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::set_coef(double a0, double a1, double a2, double b0, double b1, double b2)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::set_coef(double a0, double a1, double a2, double b0, double b1, double b2)
 {
     double a0inv = 1 / a0;
 
@@ -449,7 +471,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     this->b2.newValue(b2);
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::process_block(float *data)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::process_block(float *data)
 {
     {
         int k;
@@ -475,7 +497,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::process_block_to(float *__restrict data, float *__restrict dataout)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::process_block_to(float *__restrict data, float *__restrict dataout)
 {
     {
         int k;
@@ -501,7 +523,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::process_block_slowlag(float *__restrict dataL, float *__restrict dataR)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::process_block_slowlag(float *__restrict dataL, float *__restrict dataR)
 {
     {
         a1.process();
@@ -536,7 +558,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::process_block(float *dataL, float *dataR)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::process_block(float *dataL, float *dataR)
 {
     {
         int k;
@@ -571,7 +593,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::process_block_to(float *dataL, float *dataR, float *dstL, float *dstR)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::process_block_to(float *dataL, float *dataR, float *dstL, float *dstR)
 {
     {
         int k;
@@ -606,7 +628,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::process_block(double *data)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::process_block(double *data)
 {
     {
         int k;
@@ -632,7 +654,7 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
     }
 }
 
-template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>::setBlockSize(int bs)
+template <typename D, size_t BLOCK_SIZE, typename Adapter> inline void BiquadFilter<D, BLOCK_SIZE, Adapter>::setBlockSize(int bs)
 {
     /*	a1.setBlockSize(bs);
             a2.setBlockSize(bs);
@@ -641,8 +663,8 @@ template <typename D, size_t BLOCK_SIZE> inline void BiquadFilter<D, BLOCK_SIZE>
             b2.setBlockSize(bs);*/
 }
 
-template<typename D, size_t BLOCK_SIZE>
-inline float BiquadFilter<D, BLOCK_SIZE>::plot_magnitude(float f)
+template<typename D, size_t BLOCK_SIZE, typename Adapter>
+inline float BiquadFilter<D, BLOCK_SIZE, Adapter>::plot_magnitude(float f)
 {
     std::complex<double> ca0(1, 0), ca1(a1.v.d[0], 0), ca2(a2.v.d[0], 0), cb0(b0.v.d[0], 0),
         cb1(b1.v.d[0], 0), cb2(b2.v.d[0], 0);


### PR DESCRIPTION
Not every class implements ->foo so make a A::Foo(s) which defaults to s->foo but can be overriden.