### PR TITLE
Back out the null provider fix

### DIFF
--- a/include/sst/filters/FilterCoefficientMaker.h
+++ b/include/sst/filters/FilterCoefficientMaker.h
@@ -36,9 +36,6 @@ constexpr int n_cm_coeffs = 8;
  */
 template <typename TuningProvider = detail::BasicTuningProvider> class FilterCoefficientMaker
 {
-    static_assert(std::is_default_constructible_v<TuningProvider>,
-                  "Tuning Provider must have a () ctor");
-
   public:
     /** Default constructor */
     FilterCoefficientMaker();
@@ -108,8 +105,6 @@ template <typename TuningProvider = detail::BasicTuningProvider> class FilterCoe
     bool FirstRun = true;
 
     TuningProvider *provider = nullptr;
-
-    static TuningProvider baseTuningProviderInstance;
 
     float sampleRate = 48000.0f;
     float sampleRateInv = 1.0f / sampleRate;

--- a/include/sst/filters/FilterCoefficientMaker_Impl.h
+++ b/include/sst/filters/FilterCoefficientMaker_Impl.h
@@ -84,18 +84,12 @@ void FilterCoefficientMaker<TuningProvider>::updateCoefficients(StateType &state
 }
 
 template <typename TuningProvider>
-TuningProvider FilterCoefficientMaker<TuningProvider>::baseTuningProviderInstance;
-
-template <typename TuningProvider>
 void FilterCoefficientMaker<TuningProvider>::MakeCoeffs(float Freq, float Reso, FilterType Type,
                                                         FilterSubType SubType,
                                                         TuningProvider *providerI,
                                                         bool tuningAdjusted, float extra,
                                                         float extra2, float extra3)
 {
-    if (!providerI)
-        providerI = &baseTuningProviderInstance;
-
     provider = providerI;
     if (provider)
     {


### PR DESCRIPTION
The null provider fix I provided was too onerous on the TuningProvider API to allow surge to work, so back it out for now so Surge can update, then do a separate template based static-or-runtime fix as a second step.