### PR TITLE
Cytomic in Quad Form and some API extensions

### DIFF
--- a/include/sst/filters++/api.h
+++ b/include/sst/filters++/api.h
@@ -200,6 +200,14 @@ struct Filter
                           float extra2 = 0.f, float extra3 = 0.f);
 
     /**
+     * If you want two voices to share coefficients - so a stereo pair with the same cutoff
+     * and resonance for instance - it is usually faster to copy coefficients from voice A to voice
+     * B that it is to compute them twice. The voices retain independent registers of course, so
+     * will still do stereo or quad processing.
+     */
+    void copyCoefficientsFromVoiceToVoice(int from, int to);
+
+    /**
      * With a given voice, for a given cutoff and resonance, set the internal coefficient
      * state. This method will assume the coefficients are fixed and so is appropriate for
      * static filter configurations and only needs to be called once, between prepareInstance

--- a/include/sst/filters++/details/filter_impl.h
+++ b/include/sst/filters++/details/filter_impl.h
@@ -60,6 +60,15 @@ inline int Filter::coefficientsExtraCount(FilterModels model, const ModelConfig 
         return config.st == SlopeLevels::Slope_Morph ? 1 : 0;
     case FilterModels::Comb:
         return config.st == SlopeLevels::Comb_Bipolar_ContinuousMix ? 1 : 0;
+    case FilterModels::CytomicSVF:
+    {
+        if (config.pt == PassTypes::Bell || config.pt == PassTypes::LowShelf ||
+            config.pt == PassTypes::HighShelf)
+        {
+            return 1;
+        }
+        return 0;
+    }
     default:
         return 0;
     }
@@ -81,6 +90,16 @@ inline void Filter::makeCoefficients(int voice, float cutoff, float resonance, f
                                          extra2, extra3);
     }
     break;
+    }
+}
+
+inline void Filter::copyCoefficientsFromVoiceToVoice(int from, int to)
+{
+    for (int i = 0; i < sst::filters::n_cm_coeffs; ++i)
+    {
+        payload.makers[to].C[i] = payload.makers[from].C[i];
+        payload.makers[to].tC[i] = payload.makers[from].dC[i];
+        payload.makers[to].tC[i] = payload.makers[from].dC[i];
     }
 }
 
@@ -131,8 +150,8 @@ inline std::vector<FilterModels> Filter::availableModels()
     return {FilterModels::VemberClassic, FilterModels::VemberAllPass, FilterModels::VemberLadder,
             FilterModels::OBXD_2Pole,    FilterModels::OBXD_4Pole,    FilterModels::K35,
             FilterModels::DiodeLadder,   FilterModels::VintageLadder, FilterModels::CutoffWarp,
-            FilterModels::ResonanceWarp, FilterModels::TriPole,       FilterModels::Comb,
-            FilterModels::SampleAndHold};
+            FilterModels::ResonanceWarp, FilterModels::CytomicSVF,    FilterModels::TriPole,
+            FilterModels::Comb,          FilterModels::SampleAndHold};
 }
 
 inline size_t Filter::requiredDelayLinesSizes(FilterModels model, const ModelConfig &k)

--- a/include/sst/filters++/details/filter_payload.h
+++ b/include/sst/filters++/details/filter_payload.h
@@ -149,6 +149,7 @@ struct FilterPayload
 #include "../models/SampleAndHold.h"
 #include "../models/Comb.h"
 #include "../models/Tripole.h"
+#include "../models/CytomicSVF.h"
 
 namespace sst::filtersplusplus::details
 {
@@ -187,6 +188,7 @@ inline FilterPayload::legacyType_t FilterPayload::resolveLegacyType()
         FILTER_MODEL_CASE(FilterModels::SampleAndHold, models::sampleandhold);
         FILTER_MODEL_CASE(FilterModels::Comb, models::comb);
         FILTER_MODEL_CASE(FilterModels::TriPole, models::tripole);
+        FILTER_MODEL_CASE(FilterModels::CytomicSVF, models::cytomicsvf);
     default:
         // remove this
         break;
@@ -232,6 +234,7 @@ inline std::vector<ModelConfig> FilterPayload::availableModelConfigurations(Filt
         FILTER_MODEL_CASE(FilterModels::SampleAndHold, models::sampleandhold);
         FILTER_MODEL_CASE(FilterModels::Comb, models::comb);
         FILTER_MODEL_CASE(FilterModels::TriPole, models::tripole);
+        FILTER_MODEL_CASE(FilterModels::CytomicSVF, models::cytomicsvf);
     default:
         // remove this
         break;

--- a/include/sst/filters++/enums.h
+++ b/include/sst/filters++/enums.h
@@ -22,28 +22,31 @@
 namespace sst::filtersplusplus
 {
 // If you add a model here, add it to Filter::availableModels in details/filter_impl too
+// I'm also generally trying to keep the enum values below 0xFF but nothing will break if you dont
 enum struct FilterModels : uint32_t
 {
     Off = 0,
 
-    VemberClassic = 0x100,
-    VemberAllPass = 0x105,
-    VemberLadder = 0x110,
+    VemberClassic = 0x10,
+    VemberAllPass = 0x15,
+    VemberLadder = 0x18,
 
-    K35 = 0x300,
-    DiodeLadder = 0x310,
+    CytomicSVF = 0x20,
 
-    VintageLadder = 0x320,
+    K35 = 0x30,
+    DiodeLadder = 0x35,
 
-    CutoffWarp = 0x330,
-    ResonanceWarp = 0x340,
+    OBXD_4Pole = 0x40,
+    OBXD_2Pole = 0x45,
 
-    OBXD_4Pole = 0x350,
-    OBXD_2Pole = 0x360,
+    VintageLadder = 0x50,
 
-    TriPole = 0x400,
-    Comb = 0x410,          // Including pos and neg
-    SampleAndHold = 0x420, // Including pos and neg
+    CutoffWarp = 0x60,
+    ResonanceWarp = 0x65,
+
+    TriPole = 0x70,
+    Comb = 0x80, // Including pos and neg
+    SampleAndHold = 0x85
 };
 
 std::string toString(const FilterModels &f);
@@ -58,9 +61,9 @@ enum struct PassTypes : uint32_t
     Notch = 0x10,
     Peak = 0x14,
     AllPass = 0x18,
-    LowShelf = 0x300,
-    Bell = 0x400,
-    HighShelf = 0x500
+    LowShelf = 0x50,
+    Bell = 0x60,
+    HighShelf = 0x70
 };
 
 std::string toString(const PassTypes &p);
@@ -69,28 +72,25 @@ enum struct SlopeLevels : uint32_t
 {
     UNSUPPORTED = 0,
 
-    Slope_6db = 0x100,
+    Slope_6db = 0x06,
+    Slope_12db = 0x12,
+    Slope_18db = 0x18,
+    Slope_24db = 0x24,
 
-    Slope_12db = 0x200,
+    Slope_1Stage = 0x30,
+    Slope_2Stage = 0x31,
+    Slope_3Stage = 0x32,
+    Slope_4Stage = 0x33,
 
-    Slope_18db = 0x300,
+    Slope_Morph = 0x40,
 
-    Slope_24db = 0x400,
-
-    Slope_1Stage = 0x450,
-    Slope_2Stage = 0x460,
-    Slope_3Stage = 0x470,
-    Slope_4Stage = 0x480,
-
-    Slope_Morph = 0x500,
-
-    Comb_Negative_ContinuousMix = 0x590,
-    Comb_Negative_100 = 0x600,
-    Comb_Negative_50 = 0x610,
-    Comb_Positive_50 = 0x620,
-    Comb_Positive_100 = 0x630,
-    Comb_Positive_ContinuousMix = 0x640,
-    Comb_Bipolar_ContinuousMix = 0x650
+    Comb_Negative_ContinuousMix = 0x50,
+    Comb_Negative_100 = 0x51,
+    Comb_Negative_50 = 0x52,
+    Comb_Positive_50 = 0x53,
+    Comb_Positive_100 = 0x54,
+    Comb_Positive_ContinuousMix = 0x55,
+    Comb_Bipolar_ContinuousMix = 0x56
 };
 
 std::string toString(const SlopeLevels &s);
@@ -100,22 +100,22 @@ enum struct DriveTypes : uint32_t
     UNSUPPORTED = 0,
 
     Standard = 0x10,
-    Clean = 0x20,
-    Driven = 0x30,
-    NotchMild = 0x40,
+    Clean = 0x12,
+    Driven = 0x14,
+    NotchMild = 0x18,
 
-    K35_None = 0x100,
-    K35_Mild = 0x105,
-    K35_Moderate = 0x109,
-    K35_Heavy = 0x10C,
-    K35_Extreme = 0x10F,
+    K35_None = 0x30,
+    K35_Mild = 0x32,
+    K35_Moderate = 0x34,
+    K35_Heavy = 0x36,
+    K35_Extreme = 0x38,
 
     // For the res and cutoff warp circuits
-    Tanh = 0x150,
-    SoftClip = 0x160,
-    OJD = 0x170,
+    Tanh = 0x40,
+    SoftClip = 0x42,
+    OJD = 0x44,
 
-    Pushed = 0x200
+    Pushed = 0x50
 };
 
 std::string toString(const DriveTypes &d);
@@ -125,19 +125,19 @@ enum struct SubModelTypes : uint32_t
     UNSUPPORTED = 0,
 
     // For obxd
-    BrokenOBXD4Pole24 = 0x700,
+    BrokenOBXD4Pole24 = 0x10,
 
     // For vintage ladder
-    RungeKutta = 0x800,
-    RungeKuttaCompensated = 0x801,
-    Huov = 0x802,
-    HuovCompensated = 0x803,
+    RungeKutta = 0x20,
+    RungeKuttaCompensated = 0x22,
+    Huov = 0x24,
+    HuovCompensated = 0x26,
 
     // For tripole
-    LowLowLow = 0x900,
-    LowHighLow = 0x902,
-    HighLowHigh = 0x903,
-    HighHighHigh = 0x904
+    LowLowLow = 0x30 + 0b000,
+    LowHighLow = 0x30 + 0b010,
+    HighLowHigh = 0x30 + 0b101,
+    HighHighHigh = 0x30 + 0b111
 };
 
 std::string toString(const SubModelTypes &s);

--- a/include/sst/filters++/enums_to_string.h
+++ b/include/sst/filters++/enums_to_string.h
@@ -34,6 +34,9 @@ inline std::string toString(const FilterModels &f)
     case FilterModels::VemberLadder:
         return "VemberLadder";
 
+    case FilterModels::CytomicSVF:
+        return "Cytomic SVF";
+
     case FilterModels::K35:
         return "K35";
     case FilterModels::DiodeLadder:

--- a/include/sst/filters++/models/CytomicSVF.h
+++ b/include/sst/filters++/models/CytomicSVF.h
@@ -1,0 +1,49 @@
+/*
+ * sst-filters - A header-only collection of SIMD filter
+ * implementations by the Surge Synth Team
+ *
+ * Copyright 2019-2025, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-filters is released under the Gnu General Public Licens
+ * version 3 or later. Some of the filters in this package
+ * originated in the version of Surge open sourced in 2018.
+ *
+ * All source in sst-filters available at
+ * https://github.com/surge-synthesizer/sst-filters
+ */
+
+#ifndef INCLUDE_SST_FILTERS_PLUS_PLUS_MODELS_CYTOMICSVF_H
+#define INCLUDE_SST_FILTERS_PLUS_PLUS_MODELS_CYTOMICSVF_H
+
+#include "sst/filters.h"
+
+#include <unordered_set>
+
+namespace sst::filtersplusplus::models::cytomicsvf
+{
+inline const details::FilterPayload::configMap_t &getModelConfigurations()
+{
+    namespace sft = sst::filters;
+    static details::FilterPayload::configMap_t configs{
+        {{PassTypes::LP}, {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_lp}},
+        {{PassTypes::HP}, {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_hp}},
+        {{PassTypes::BP}, {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_bp}},
+        {{PassTypes::Notch},
+         {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_notch}},
+        {{PassTypes::Peak}, {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_peak}},
+        {{PassTypes::AllPass},
+         {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_all}},
+        {{PassTypes::LP}, {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_lp}},
+        {{PassTypes::LowShelf},
+         {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_lowshelf}},
+        {{PassTypes::HighShelf},
+         {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_highhelf}},
+        {{PassTypes::Bell}, {sft::FilterType::fut_cytomicsvf, sft::FilterSubType::st_cytomic_bell}},
+
+    };
+    return configs;
+}
+} // namespace sst::filtersplusplus::models::cytomicsvf
+
+#endif // CYTOMICSVF_H

--- a/include/sst/filters/CytomicSVF.h
+++ b/include/sst/filters/CytomicSVF.h
@@ -58,6 +58,9 @@
  * Higher level functions like when to call the setCoeff
  * and how to run as a block are left as an exercise to the client of this
  * class. This is just the raw functions coded up.
+ *
+ * To use this in the filters++ or filters api, see the
+ * re-implementation in CytomicSVFQuadForm
  */
 
 namespace sst::filters

--- a/include/sst/filters/CytomicSVFQuadForm.h
+++ b/include/sst/filters/CytomicSVFQuadForm.h
@@ -1,0 +1,180 @@
+/*
+ * sst-filters - A header-only collection of SIMD filter
+ * implementations by the Surge Synth Team
+ *
+ * Copyright 2019-2025, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-filters is released under the Gnu General Public Licens
+ * version 3 or later. Some of the filters in this package
+ * originated in the version of Surge open sourced in 2018.
+ *
+ * All source in sst-filters available at
+ * https://github.com/surge-synthesizer/sst-filters
+ */
+
+#ifndef INCLUDE_SST_FILTERS_CYTOMICSVFQUADFORM_H
+#define INCLUDE_SST_FILTERS_CYTOMICSVFQUADFORM_H
+
+#include "QuadFilterUnit.h"
+
+namespace sst::filters::cytomic_quadform
+{
+
+struct Coeff
+{
+    // not an enum to avoid annoying casts
+    static constexpr int a1 = 0;
+    static constexpr int a2 = 1;
+    static constexpr int a3 = 2;
+    static constexpr int m0 = 3;
+    static constexpr int m1 = 4;
+    static constexpr int m2 = 5;
+};
+
+struct Reg
+{
+    static constexpr int ic1eq = 0;
+    static constexpr int ic2eq = 1;
+};
+
+template <typename TuningProvider>
+void makeCoefficients(FilterCoefficientMaker<TuningProvider> *cm, float freq, float res,
+                      int subtype, float sampleRate, float sampleRateInv, TuningProvider *provider,
+                      float bellShelfAmp)
+{
+    auto ufr = 440 * FilterCoefficientMaker<TuningProvider>::provider_note_to_pitch_ignoring_tuning(
+                         provider, freq);
+    auto conorm = std::clamp(ufr * sampleRateInv, 0.f, 0.499f); // stable until nyquist
+    static float lf{-1000}, lr{-1000};
+
+    lf = freq;
+    lr = res;
+    res = std::clamp(res, 0.f, 0.99f);
+
+    auto g = sst::basic_blocks::dsp::fasttan(M_PI * conorm);
+    auto k = 2.0 - 2 * res;
+
+    if (subtype == st_cytomic_bell)
+    {
+        bellShelfAmp = std::max(bellShelfAmp, 0.001f);
+        k = k / bellShelfAmp;
+    }
+
+    auto gk = g + k;
+    cm->C[Coeff::a1] = 1.0 / (1 + g * gk);
+    cm->C[Coeff::a2] = g * cm->C[Coeff::a1];
+    cm->C[Coeff::a3] = g * cm->C[Coeff::a2];
+
+    switch (subtype)
+    {
+    case st_cytomic_lp:
+        // The lowpass opt below hardcodes these so we can skip this assignment
+        // cm->C[Coeff::m0] = 0.0;
+        // cm->C[Coeff::m1] = 0.0;
+        // cm->C[Coeff::m2] = 1.0;
+        break;
+    case st_cytomic_bp:
+        cm->C[Coeff::m0] = 0.0;
+        cm->C[Coeff::m1] = 1.0;
+        cm->C[Coeff::m2] = 0.0;
+        break;
+    case st_cytomic_hp:
+        cm->C[Coeff::m0] = 1.0;
+        cm->C[Coeff::m1] = -k;
+        cm->C[Coeff::m2] = -1;
+        break;
+    case st_cytomic_notch:
+        cm->C[Coeff::m0] = 1.0;
+        cm->C[Coeff::m1] = 1 - k;
+        cm->C[Coeff::m2] = 0;
+        break;
+    case st_cytomic_peak:
+        cm->C[Coeff::m0] = 1.0;
+        cm->C[Coeff::m1] = -k;
+        cm->C[Coeff::m2] = -2;
+        break;
+    case st_cytomic_all:
+        cm->C[Coeff::m0] = 1.0;
+        cm->C[Coeff::m1] = -2 * k;
+        cm->C[Coeff::m2] = 0;
+        break;
+    case st_cytomic_bell:
+    {
+        auto A = std::clamp(bellShelfAmp, 0.001f, 0.999f);
+        cm->C[Coeff::m0] = 1.0;
+        cm->C[Coeff::m1] = k * (A * A - 1);
+        cm->C[Coeff::m2] = 0;
+    }
+    break;
+    case st_cytomic_lowshelf:
+    {
+        auto A = std::clamp(bellShelfAmp, 0.001f, 0.999f);
+        cm->C[Coeff::m0] = 1.0;
+        cm->C[Coeff::m1] = k * (A - 1);
+        cm->C[Coeff::m2] = A * A - 1;
+    }
+    break;
+    case st_cytomic_highhelf:
+    {
+        auto A = std::clamp(bellShelfAmp, 0.001f, 0.999f);
+        cm->C[Coeff::m0] = A * A;
+        cm->C[Coeff::m1] = A * k * (1 - A);
+        cm->C[Coeff::m2] = 1 - A * A;
+    }
+    break;
+    }
+}
+
+#define ADD(a, b) SIMD_MM(add_ps)(a, b)
+#define SUB(a, b) SIMD_MM(sub_ps)(a, b)
+#define DIV(a, b) SIMD_MM(div_ps)(a, b)
+#define MUL(a, b) SIMD_MM(mul_ps)(a, b)
+
+// a very common case is low pas which has m0=m1=0 and m2=1 so hardcode that in.
+template <bool lowPassOpt = false>
+inline SIMD_M128 CytomicQuad(QuadFilterUnitState *__restrict f, SIMD_M128 vin)
+{
+    if (lowPassOpt) // m0 == m1 == m2 == 0
+    {
+        for (int i = 0; i <= Coeff::a3; ++i)
+            f->C[i] = SIMD_MM(add_ps)(f->C[i], f->dC[i]);
+    }
+    else
+    {
+        for (int i = 0; i <= Coeff::m2; ++i)
+            f->C[i] = SIMD_MM(add_ps)(f->C[i], f->dC[i]);
+    }
+
+    auto v3 = SUB(vin, f->R[Reg::ic2eq]);
+
+    // v1 = a1 * ic1eq + a2 * v3
+    auto v1 = ADD(MUL(f->C[Coeff::a1], f->R[Reg::ic1eq]), MUL(f->C[Coeff::a2], v3));
+
+    // v2 = ic2eq + a2 * ic1eq + a3 * v3
+    auto v2 = ADD(f->R[Reg::ic2eq],
+                  ADD(MUL(f->C[Coeff::a2], f->R[Reg::ic1eq]), MUL(f->C[Coeff::a3], v3)));
+
+    // ic1eq = 2 * v1 - ic1eq
+    auto twoSSE = SIMD_MM(set1_ps)(2.0f);
+    f->R[Reg::ic1eq] = SUB(MUL(twoSSE, v1), f->R[Reg::ic1eq]);
+
+    // ic2eq = 2 * v2 - ic2eq
+    f->R[Reg::ic2eq] = SUB(MUL(twoSSE, v2), f->R[Reg::ic2eq]);
+
+    // (m0 * input) + ((m1 * v1) + (m2 * v2))
+    if (lowPassOpt) // m0 == m1 = 0
+        return v2;
+    else
+        return ADD(MUL(f->C[Coeff::m0], vin),
+                   ADD(MUL(f->C[Coeff::m1], v1), MUL(f->C[Coeff::m2], v2)));
+}
+
+#undef ADD
+#undef SUB
+#undef DIV
+#undef MUL
+#undef SETALL
+} // namespace sst::filters::cytomic_quadform
+
+#endif // CYTOMICSVFQUADFORM_H

--- a/include/sst/filters/FilterCoefficientMaker_Impl.h
+++ b/include/sst/filters/FilterCoefficientMaker_Impl.h
@@ -358,6 +358,10 @@ void FilterCoefficientMaker<TuningProvider>::MakeCoeffs(float Freq, float Reso, 
         TriPoleFilter::makeCoefficients(this, Freq, Reso, Type, sampleRate, providerI);
         break;
 
+    case fut_cytomicsvf:
+        cytomic_quadform::makeCoefficients(this, Freq, Reso, SubType, sampleRate, sampleRateInv,
+                                           providerI, extra);
+
     case num_filter_types:
         // This should really be an error condition of course
     case fut_none:

--- a/include/sst/filters/FilterConfiguration.h
+++ b/include/sst/filters/FilterConfiguration.h
@@ -56,6 +56,7 @@ enum FilterType
     fut_resonancewarp_bp, /**< Bandpass - Resonance Warp */
     fut_resonancewarp_ap, /**< Effect - Resonance Warp Allpass */
     fut_tripole,          /**< Multi - Tri-pole */
+    fut_cytomicsvf,
     num_filter_types,
 };
 
@@ -100,6 +101,7 @@ const char filter_type_names[num_filter_types][32] = {
     "BP Res Warp",       // fut_resonancewarp_bp
     "FX Res Warp AP",    // fut_resonancewarp_ap
     "MULTI Tri-pole",    // fut_tripole
+    "Cytomic SVF",
     /* this is a ruler to ensure names do not exceed 31 characters
      0123456789012345678901234567890
     */
@@ -140,6 +142,7 @@ const char filter_menu_names[num_filter_types][32] = {
     "Resonance Warp", // BP
     "Resonance Warp Allpass",
     "Tri-pole",
+    "Cytomic SVF",
     /* this is a ruler to ensure names do not exceed 31 characters
      0123456789012345678901234567890
     */
@@ -333,6 +336,17 @@ enum FilterSubType
     // Legacy fixes for BP12 misconfiguration
     st_bp12_LegacyDriven = 3,
     st_bp12_LegacyClean = 4,
+
+    // Cytomic has the passtypes as syb models
+    st_cytomic_lp = 0,
+    st_cytomic_hp = 1,
+    st_cytomic_bp = 2,
+    st_cytomic_notch = 3,
+    st_cytomic_peak = 4,
+    st_cytomic_all = 5,
+    st_cytomic_bell = 6, // these three use "extra1"
+    st_cytomic_lowshelf = 7,
+    st_cytomic_highhelf = 8
 };
 
 } // namespace sst::filters

--- a/include/sst/filters/FilterConfigurationLabels.h
+++ b/include/sst/filters/FilterConfigurationLabels.h
@@ -100,6 +100,10 @@ static std::string subtypeLabel(int type, int subtype)
             return fmt::format("{} {}", sst::filters::fut_tripole_subtypes[i & 3],
                                sst::filters::fut_tripole_output_stage[(i >> 2) & 3]);
             break;
+        case FilterType:
+        fut_cytomicsvf:
+            return "t/k";
+            break;
         case FilterType::num_filter_types:
             return "ERROR";
             break;

--- a/include/sst/filters/QuadFilterUnit_Impl.h
+++ b/include/sst/filters/QuadFilterUnit_Impl.h
@@ -26,6 +26,7 @@
 #include "CutoffWarp.h"
 #include "ResonanceWarp.h"
 #include "TriPoleFilter.h"
+#include "CytomicSVFQuadForm.h"
 
 namespace sst::filters
 {
@@ -947,6 +948,12 @@ inline FilterUnitQFPtr GetCompensatedQFPtrFilterUnit(FilterType type, FilterSubT
             break;
         }
         break;
+    case fut_cytomicsvf:
+        if (subtype == st_cytomic_lp)
+            return cytomic_quadform::CytomicQuad<true>;
+        else
+            return cytomic_quadform::CytomicQuad;
+
     case fut_none:
     case num_filter_types:
         break;

--- a/tests/CytomicSVFTests.cpp
+++ b/tests/CytomicSVFTests.cpp
@@ -15,6 +15,7 @@
 
 #include "catch2/catch2.hpp"
 #include "sst/filters/CytomicSVF.h"
+#include "TestUtils.h"
 
 #include <iostream>
 #include <cmath>
@@ -183,4 +184,36 @@ TEST_CASE("Cytomic SVF Response Curves")
             }
         }
     }
+}
+
+TEST_CASE("Cytomic SVF QuadFilter Test")
+{
+    using namespace TestUtils;
+    namespace sfpp = sst::filtersplusplus;
+
+    std::vector<RMSSet> ans = {
+        {-2.81053f, -2.27167f, -3.09009f, -16.3563f, -51.5564f},
+        {-31.4792f, -15.8393f, -3.12771f, -2.2901f, -3.00617f},
+        {-17.8248f, -9.17934f, -3.11892f, -9.39847f, -31.4778f},
+        {-2.92205f, -3.02689f, -3.00706f, -3.01887f, -3.01214f},
+        {-2.52717f, -0.639164f, 2.90231f, -0.742297f, -2.99382f},
+        {-2.99243f, -3.0779f, -3.15685f, -3.02565f, -3.01241f},
+    };
+    runTest({FilterType::fut_cytomicsvf, FilterSubType::st_cytomic_lp, ans[0]});
+    runTest(sfpp::FilterModels::CytomicSVF, sfpp::PassTypes::LP, 0, 0.5, ans[0]);
+
+    runTest({FilterType::fut_cytomicsvf, FilterSubType::st_cytomic_hp, ans[1]});
+    runTest(sfpp::FilterModels::CytomicSVF, sfpp::PassTypes::HP, 0, 0.5, ans[1]);
+
+    runTest({FilterType::fut_cytomicsvf, FilterSubType::st_cytomic_bp, ans[2]});
+    runTest(sfpp::FilterModels::CytomicSVF, sfpp::PassTypes::BP, 0, 0.5, ans[2]);
+
+    runTest({FilterType::fut_cytomicsvf, FilterSubType::st_cytomic_notch, ans[3]});
+    runTest(sfpp::FilterModels::CytomicSVF, sfpp::PassTypes::Notch, 0, 0.5, ans[3]);
+
+    runTest({FilterType::fut_cytomicsvf, FilterSubType::st_cytomic_peak, ans[4]});
+    runTest(sfpp::FilterModels::CytomicSVF, sfpp::PassTypes::Peak, 0, 0.5, ans[4]);
+
+    runTest({FilterType::fut_cytomicsvf, FilterSubType::st_cytomic_all, ans[5]});
+    runTest(sfpp::FilterModels::CytomicSVF, sfpp::PassTypes::AllPass, 0, 0.5, ans[5]);
 }


### PR DESCRIPTION
1. Add the CytomicSVF in QuadFilterUnit form also so that it is available to surge-style and new-style quad filter apis.

2. Add a copyCoefficients api to the new api so you can configure one voice and use in all

3. Reset the enums to be in a range generally <0xff each

4. brute foce filter can do extra/moprh sweeps