### PR TITLE
Implement the OBXD XPander and improve the 4 pole

### DIFF
--- a/include/sst/filters++/details/filter_impl.h
+++ b/include/sst/filters++/details/filter_impl.h
@@ -150,10 +150,10 @@ inline void Filter::concludeBlock()
 inline std::vector<FilterModels> Filter::availableModels()
 {
     return {FilterModels::VemberClassic, FilterModels::VemberAllPass, FilterModels::VemberLadder,
-            FilterModels::OBXD_2Pole,    FilterModels::OBXD_4Pole,    FilterModels::K35,
-            FilterModels::DiodeLadder,   FilterModels::VintageLadder, FilterModels::CutoffWarp,
-            FilterModels::ResonanceWarp, FilterModels::CytomicSVF,    FilterModels::TriPole,
-            FilterModels::Comb,          FilterModels::SampleAndHold};
+            FilterModels::OBXD_2Pole,    FilterModels::OBXD_4Pole,    FilterModels::OBXD_XPander,
+            FilterModels::K35,           FilterModels::DiodeLadder,   FilterModels::VintageLadder,
+            FilterModels::CutoffWarp,    FilterModels::ResonanceWarp, FilterModels::CytomicSVF,
+            FilterModels::TriPole,       FilterModels::Comb,          FilterModels::SampleAndHold};
 }
 
 inline size_t Filter::requiredDelayLinesSizes(FilterModels model, const ModelConfig &k)

--- a/include/sst/filters++/details/filter_payload.h
+++ b/include/sst/filters++/details/filter_payload.h
@@ -145,6 +145,7 @@ struct FilterPayload
 #include "../models/ResonanceWarp.h"
 #include "../models/DiodeLadder.h"
 #include "../models/OBXD_4Pole.h"
+#include "../models/OBXD_XPander.h"
 #include "../models/OBXD_2Pole.h"
 #include "../models/SampleAndHold.h"
 #include "../models/Comb.h"
@@ -185,6 +186,7 @@ inline FilterPayload::legacyType_t FilterPayload::resolveLegacyType()
         FILTER_MODEL_CASE(FilterModels::DiodeLadder, models::diodeladder);
         FILTER_MODEL_CASE(FilterModels::OBXD_4Pole, models::obxd_4pole);
         FILTER_MODEL_CASE(FilterModels::OBXD_2Pole, models::obxd_2pole);
+        FILTER_MODEL_CASE(FilterModels::OBXD_XPander, models::obxd_xpander);
         FILTER_MODEL_CASE(FilterModels::SampleAndHold, models::sampleandhold);
         FILTER_MODEL_CASE(FilterModels::Comb, models::comb);
         FILTER_MODEL_CASE(FilterModels::TriPole, models::tripole);
@@ -231,6 +233,7 @@ inline std::vector<ModelConfig> FilterPayload::availableModelConfigurations(Filt
         FILTER_MODEL_CASE(FilterModels::DiodeLadder, models::diodeladder);
         FILTER_MODEL_CASE(FilterModels::OBXD_4Pole, models::obxd_4pole);
         FILTER_MODEL_CASE(FilterModels::OBXD_2Pole, models::obxd_2pole);
+        FILTER_MODEL_CASE(FilterModels::OBXD_XPander, models::obxd_xpander);
         FILTER_MODEL_CASE(FilterModels::SampleAndHold, models::sampleandhold);
         FILTER_MODEL_CASE(FilterModels::Comb, models::comb);
         FILTER_MODEL_CASE(FilterModels::TriPole, models::tripole);

--- a/include/sst/filters++/enums.h
+++ b/include/sst/filters++/enums.h
@@ -38,6 +38,7 @@ enum struct FilterModels : uint32_t
 
     OBXD_4Pole = 0x40,
     OBXD_2Pole = 0x45,
+    OBXD_XPander = 0x47,
 
     VintageLadder = 0x50,
 
@@ -63,7 +64,13 @@ enum struct PassTypes : uint32_t
     AllPass = 0x18,
     LowShelf = 0x50,
     Bell = 0x60,
-    HighShelf = 0x70
+    HighShelf = 0x70,
+
+    Phaser = 0x80,
+
+    HPAndLP = 0x90,
+    NotchAndLP = 0x92,
+    PhaserAndLP = 0x94
 };
 
 std::string toString(const PassTypes &p);

--- a/include/sst/filters++/enums_to_string.h
+++ b/include/sst/filters++/enums_to_string.h
@@ -54,6 +54,8 @@ inline std::string toString(const FilterModels &f)
         return "OB-Xd 24 dB";
     case FilterModels::OBXD_2Pole:
         return "OB-Xd 12 dB";
+    case FilterModels::OBXD_XPander:
+        return "OB-Xd XPander";
 
     case FilterModels::TriPole:
         return "Tri-Pole";
@@ -90,6 +92,15 @@ inline std::string toString(const PassTypes &p)
         return "Bell";
     case PassTypes::HighShelf:
         return "High Shelf";
+
+    case PassTypes::Phaser:
+        return "Phaser";
+    case PassTypes::HPAndLP:
+        return "HP + LP";
+    case PassTypes::NotchAndLP:
+        return "Notch + LP";
+    case PassTypes::PhaserAndLP:
+        return "Phaser + LP";
     }
     return "PASSTYPE_ERROR";
 }

--- a/include/sst/filters++/models/OBXD_XPander.h
+++ b/include/sst/filters++/models/OBXD_XPander.h
@@ -1,0 +1,67 @@
+/*
+ * sst-filters - A header-only collection of SIMD filter
+ * implementations by the Surge Synth Team
+ *
+ * Copyright 2019-2025, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-filters is released under the Gnu General Public Licens
+ * version 3 or later. Some of the filters in this package
+ * originated in the version of Surge open sourced in 2018.
+ *
+ * All source in sst-filters available at
+ * https://github.com/surge-synthesizer/sst-filters
+ */
+
+#ifndef INCLUDE_SST_FILTERS_PLUS_PLUS_MODELS_OBXD_XPANDER_H
+#define INCLUDE_SST_FILTERS_PLUS_PLUS_MODELS_OBXD_XPANDER_H
+
+#include "sst/filters.h"
+
+#include <unordered_set>
+
+namespace sst::filtersplusplus::models::obxd_xpander
+{
+inline const details::FilterPayload::configMap_t &getModelConfigurations()
+{
+    namespace sft = sst::filters;
+    static details::FilterPayload::configMap_t configs{
+        {{PassTypes::LP, SlopeLevels::Slope_6db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_lp1}},
+        {{PassTypes::LP, SlopeLevels::Slope_12db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_lp2}},
+        {{PassTypes::LP, SlopeLevels::Slope_18db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_lp3}},
+        {{PassTypes::LP, SlopeLevels::Slope_24db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_lp4}},
+
+        {{PassTypes::HP, SlopeLevels::Slope_18db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_hp3}},
+        {{PassTypes::HP, SlopeLevels::Slope_12db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_hp2}},
+        {{PassTypes::HP, SlopeLevels::Slope_6db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_hp1}},
+
+        {{PassTypes::BP, SlopeLevels::Slope_24db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_bp4}},
+        {{PassTypes::BP, SlopeLevels::Slope_12db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_bp2}},
+        {{PassTypes::Notch, SlopeLevels::Slope_12db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_n2}},
+        {{PassTypes::Phaser, SlopeLevels::Slope_18db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_ph3}},
+
+        {{PassTypes::HPAndLP, SlopeLevels::Slope_18db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_hp3lp1}},
+        {{PassTypes::HPAndLP, SlopeLevels::Slope_12db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_hp2lp1}},
+        {{PassTypes::NotchAndLP, SlopeLevels::Slope_12db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_n2lp1}},
+        {{PassTypes::PhaserAndLP, SlopeLevels::Slope_18db},
+         {sft::FilterType::fut_obxd_xpander, sft::FilterSubType::st_obxdX_ph3lp1}},
+    };
+    return configs;
+}
+} // namespace sst::filtersplusplus::models::obxd_xpander
+
+#endif // OBXF_4POLE_H

--- a/include/sst/filters/FilterCoefficientMaker_Impl.h
+++ b/include/sst/filters/FilterCoefficientMaker_Impl.h
@@ -329,6 +329,10 @@ void FilterCoefficientMaker<TuningProvider>::MakeCoeffs(float Freq, float Reso, 
                                      providerI, useM, extra);
     }
     break;
+    case fut_obxd_xpander:
+        OBXDFilter::makeCoefficients(this, OBXDFilter::XPANDER, Freq, Reso, 0, sampleRateInv,
+                                     providerI, false, extra);
+        break;
     case fut_k35_lp:
         if (SubType == st_k35_continuous)
         {

--- a/include/sst/filters/FilterConfiguration.h
+++ b/include/sst/filters/FilterConfiguration.h
@@ -57,6 +57,7 @@ enum FilterType
     fut_resonancewarp_ap, /**< Effect - Resonance Warp Allpass */
     fut_tripole,          /**< Multi - Tri-pole */
     fut_cytomicsvf,
+    fut_obxd_xpander, /**< OB-Xd XPander */
     num_filter_types,
 };
 
@@ -143,6 +144,7 @@ const char filter_menu_names[num_filter_types][32] = {
     "Resonance Warp Allpass",
     "Tri-pole",
     "Cytomic SVF",
+    "OBXD XPander"
     /* this is a ruler to ensure names do not exceed 31 characters
      0123456789012345678901234567890
     */
@@ -218,6 +220,11 @@ const char fut_tripole_output_stage[3][16]{
     "Third",
 };
 
+const char fut_obxd_xpander_subtypes[15][32] = {
+    "LP-4",     "LP-3",        "LP-2",        "LP-1",           "HP-3",
+    "HP-2",     "HP-1",        "BP-4",        "BP-2",           "Notch-2",
+    "Phaser-3", "HP-2 + LP-1", "HP-3 + LP-1", "Notch-2 + LP-1", "Phaser-3 + LP-1"};
+
 /** The number of sub-types for each filter type */
 const int fut_subcount[num_filter_types] = {
     0,  // fut_none
@@ -254,6 +261,8 @@ const int fut_subcount[num_filter_types] = {
     8,  // fut_resonancewarp_bp
     8,  // fut_resonancewarp_ap
     12, // fut_tripole
+    9,  // fut_cytomic
+    15  // fit_obxd_xpander
 };
 
 /** Sub-types for each filter are defined here */
@@ -354,7 +363,23 @@ enum FilterSubType
     st_cytomic_all = 5,
     st_cytomic_bell = 6, // these three use "extra1"
     st_cytomic_lowshelf = 7,
-    st_cytomic_highhelf = 8
+    st_cytomic_highhelf = 8,
+
+    st_obxdX_lp4 = 0,
+    st_obxdX_lp3 = 1,
+    st_obxdX_lp2 = 2,
+    st_obxdX_lp1 = 3,
+    st_obxdX_hp3 = 4,
+    st_obxdX_hp2 = 5,
+    st_obxdX_hp1 = 6,
+    st_obxdX_bp4 = 7,
+    st_obxdX_bp2 = 8,
+    st_obxdX_n2 = 9,
+    st_obxdX_ph3 = 10,
+    st_obxdX_hp2lp1 = 11,
+    st_obxdX_hp3lp1 = 12,
+    st_obxdX_n2lp1 = 13,
+    st_obxdX_ph3lp1 = 14
 };
 
 } // namespace sst::filters

--- a/include/sst/filters/QuadFilterUnit_Impl.h
+++ b/include/sst/filters/QuadFilterUnit_Impl.h
@@ -816,15 +816,64 @@ inline FilterUnitQFPtr GetCompensatedQFPtrFilterUnit(FilterType type, FilterSubT
         return OBXDFilter::process_2_pole;
         break;
     case fut_obxd_4pole:
-        if (subtype == st_obxd4pole_broken24db)
+        switch (subtype)
         {
-            return OBXDFilter::process_4_pole<true>;
+        case st_obxd4pole_6db:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP6>;
+        case st_obxd4pole_12db:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP12>;
+        case st_obxd4pole_18db:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP18>;
+        case st_obxd4pole_24db:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP24>;
+        case st_obxd4pole_broken24db:
+            return OBXDFilter::process_4_pole<OBXDFilter::LPBroken24>;
+        case st_obxd4pole_morph:
+            return OBXDFilter::process_4_pole<OBXDFilter::MORPH>;
+        default:
+            return nullptr;
         }
-        else
+
+        break;
+
+    case fut_obxd_xpander:
+        switch (subtype)
         {
-            return OBXDFilter::process_4_pole<false>;
+        case st_obxdX_lp1:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP6>;
+        case st_obxdX_lp2:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP12>;
+        case st_obxdX_lp3:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP18>;
+        case st_obxdX_lp4:
+            return OBXDFilter::process_4_pole<OBXDFilter::LP24>;
+        case st_obxdX_hp1:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_HP1>;
+        case st_obxdX_hp2:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_HP2>;
+        case st_obxdX_hp3:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_HP3>;
+        case st_obxdX_bp4:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_BP4>;
+        case st_obxdX_bp2:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_BP2>;
+        case st_obxdX_n2:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_N2>;
+        case st_obxdX_ph3:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_PH3>;
+        case st_obxdX_hp2lp1:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_HP2LP1>;
+        case st_obxdX_hp3lp1:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_HP3LP1>;
+        case st_obxdX_n2lp1:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_N2LP1>;
+        case st_obxdX_ph3lp1:
+            return OBXDFilter::process_4_pole<OBXDFilter::XPANDER_PH3LP1>;
+        default:
+            return nullptr;
         }
         break;
+
     case fut_k35_lp:
         if (Compensated && subtype == 2)
             return ScaleQFPtr<0700, K35Filter::process_lp>;

--- a/tests/OBXDFilterTest.cpp
+++ b/tests/OBXDFilterTest.cpp
@@ -85,36 +85,144 @@ TEST_CASE("OBXD Filter")
         runTest({FilterType::fut_obxd_4pole,
                  FilterSubType::st_obxd4pole_6db,
                  {-10.3241f, -6.48075f, -0.536573f, -10.2352f, -30.8738f}});
+        runTest(sfpp::FilterModels::OBXD_4Pole, {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_6db},
+                0, 0.5, {-10.3241f, -6.48075f, -0.536573f, -10.2352f, -30.8738f});
+
         runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_6db,
+                 FilterSubType::st_obxd4pole_12db,
+                 {-10.4795f, -7.32661f, -3.53102f, -18.0087f, -53.1575f}});
+        runTest(sfpp::FilterModels::OBXD_4Pole,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-10.4795f, -7.32661f, -3.53102f, -18.0087f, -53.1575f});
+
+        runTest({FilterType::fut_obxd_4pole,
+                 FilterSubType::st_obxd4pole_18db,
+                 {-10.6428f, -8.15069f, -6.50921f, -25.4671f, -56.6591f}});
+        runTest(sfpp::FilterModels::OBXD_4Pole,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_18db}, 0, 0.5,
+                {-10.6428f, -8.15069f, -6.50921f, -25.4671f, -56.6591f});
+
+        runTest({FilterType::fut_obxd_4pole,
+                 FilterSubType::st_obxd4pole_24db,
+                 {-10.8168, -8.97697, -9.51416, -31.9326, -58.5682}});
+        runTest(sfpp::FilterModels::OBXD_4Pole,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_24db}, 0, 0.5,
+                {-10.8168, -8.97697, -9.51416, -31.9326, -58.5682});
+
+        runTest({FilterType::fut_obxd_4pole,
+                 FilterSubType::st_obxd4pole_broken24db,
+                 {-4.7424f, -2.72974f, -2.51195f, -23.2202f, -51.9861f}});
+        runTest(sfpp::FilterModels::OBXD_4Pole,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_24db,
+                 sfpp::SubModelTypes::BrokenOBXD4Pole24},
+                0, 0.5, {-4.7424f, -2.72974f, -2.51195f, -23.2202f, -51.9861f});
+    }
+
+    SECTION("XPander")
+    {
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_lp1,
                  {-10.3241f, -6.48075f, -0.536573f, -10.2352f, -30.8738f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_6db}, 0, 0.5,
+                {-10.3241f, -6.48075f, -0.536573f, -10.2352f, -30.8738f});
 
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_12db,
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_lp2,
                  {-10.4795f, -7.32661f, -3.53102f, -18.0087f, -53.1575f}});
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_12db,
-                 {-10.4795f, -7.32661f, -3.53102f, -18.0087f, -53.1575f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-10.4795f, -7.32661f, -3.53102f, -18.0087f, -53.1575f});
 
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_18db,
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_lp3,
                  {-10.6428f, -8.15069f, -6.50921f, -25.4671f, -56.6591f}});
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_18db,
-                 {-10.6428f, -8.15069f, -6.50921f, -25.4671f, -56.6591f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_18db}, 0, 0.5,
+                {-10.6428f, -8.15069f, -6.50921f, -25.4671f, -56.6591f});
 
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_24db,
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_lp4,
                  {-10.8168, -8.97697, -9.51416, -31.9326, -58.5682}});
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_24db,
-                 {-10.8168, -8.97697, -9.51416, -31.9326, -58.5682}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::LP, sfpp::SlopeLevels::Slope_24db}, 0, 0.5,
+                {-10.8168, -8.97697, -9.51416, -31.9326, -58.5682});
 
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_broken24db,
-                 {-4.7424f, -2.72974f, -2.51195f, -23.2202f, -51.9861f}});
-        runTest({FilterType::fut_obxd_4pole,
-                 FilterSubType::st_obxd4pole_broken24db,
-                 {-4.7424f, -2.72974f, -2.51195f, -23.2202f, -51.9861f}});
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_hp1,
+                 {-24.9438f, -13.1056f, -0.528926f, -3.15228f, -2.41054f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::HP, sfpp::SlopeLevels::Slope_6db}, 0, 0.5,
+                {-24.9438f, -13.1056f, -0.528926f, -3.15228f, -2.41054f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_hp2,
+                 {-37.2119f, -20.5849f, -3.61575f, -3.92377f, -2.41679f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::HP, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-37.2119f, -20.5849f, -3.61575f, -3.92377f, -2.41679f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_hp3,
+                 {-43.75f, -27.6081f, -6.68905f, -4.69537f, -2.42307f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::HP, sfpp::SlopeLevels::Slope_18db}, 0, 0.5,
+                {-43.75f, -27.6081f, -6.68905f, -4.69537f, -2.42307f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_bp2,
+                 {-19.2489f, -8.01136f, 2.45672f, -5.02172f, -24.879f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::BP, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-19.2489f, -8.01136f, 2.45672f, -5.02172f, -24.879f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_bp4,
+                 {-33.002f, -16.4243f, -3.60726f, -13.6689f, -51.1749f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::BP, sfpp::SlopeLevels::Slope_24db}, 0, 0.5,
+                {-33.002f, -16.4243f, -3.60726f, -13.6689f, -51.1749f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_n2,
+                 {-10.7763f, -9.36031f, -25.7763f, -5.79322f, -2.4291f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::Notch, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-10.7763f, -9.36031f, -25.7763f, -5.79322f, -2.4291f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_ph3,
+                 {-16.1412f, -6.06469f, -0.523086f, -12.1305f, -2.4599f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::Phaser, sfpp::SlopeLevels::Slope_18db}, 0, 0.5,
+                {-16.1412f, -6.06469f, -0.523086f, -12.1305f, -2.4599f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_hp2lp1,
+                 {-38.2663f, -21.5233f, -6.59278f, -11.8341f, -30.9139f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::HPAndLP, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-38.2663f, -21.5233f, -6.59278f, -11.8341f, -30.9139f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_hp3lp1,
+                 {-46.3801f, -28.7917f, -9.65358f, -12.6151f, -30.9242f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::HPAndLP, sfpp::SlopeLevels::Slope_18db}, 0, 0.5,
+                {-46.3801f, -28.7917f, -9.65358f, -12.6151f, -30.9242f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_n2lp1,
+                 {-10.939f, -10.18f, -28.1791f, -13.7106f, -30.9311f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::NotchAndLP, sfpp::SlopeLevels::Slope_12db}, 0, 0.5,
+                {-10.939f, -10.18f, -28.1791f, -13.7106f, -30.9311f});
+
+        runTest({FilterType::fut_obxd_xpander,
+                 FilterSubType::st_obxdX_ph3lp1,
+                 {-16.3624f, -6.96748f, -3.53552f, -19.8704f, -30.9486f}});
+        runTest(sfpp::FilterModels::OBXD_XPander,
+                {sfpp::PassTypes::PhaserAndLP, sfpp::SlopeLevels::Slope_18db}, 0, 0.5,
+                {-16.3624f, -6.96748f, -3.53552f, -19.8704f, -30.9486f});
     }
 }

--- a/tests/TestUtils.h
+++ b/tests/TestUtils.h
@@ -140,11 +140,15 @@ inline void runTestProvider(const TestConfig &testConfig, TuningProvider *tp)
 
     if constexpr (printRMSs)
     {
+        auto pfx = "";
         std::cout << "{ ";
         for (int i = 0; i < numTestFreqs; ++i)
-            std::cout << actualRMSs[i] << "f, ";
+        {
+            std::cout << pfx << actualRMSs[i] << "f";
+            pfx = ", ";
+        }
 
-        std::cout << "}" << std::endl;
+        std::cout << " }" << std::endl;
     }
 };
 


### PR DESCRIPTION
1. The fixed modes in the 4 pole could avoid the blending and just grab what they need. Template trickery reduces flops as a result

2. And while in there add the xpander with all its subtypes