### PR TITLE
A legacy type static getter and filter plotter adjuster

### DIFF
--- a/include-extras/sst/filters/FilterPlotter.h
+++ b/include-extras/sst/filters/FilterPlotter.h
@@ -16,6 +16,7 @@
 #define INCLUDE_EXTRAS_SST_FILTERS_FILTERPLOTTER_H
 
 #include <sst/filters.h>
+#include <sst/filters++.h>
 
 // This header must be used inside a JUCE environment
 #include <juce_dsp/juce_dsp.h>
@@ -46,6 +47,20 @@ class FilterPlotter
     {
         return plotFilterMagnitudeResponse(filterType, filterSubType, pitch, res, 0.0f, 0.0f, 0.0f,
                                            params);
+    }
+
+    std::pair<std::vector<float>, std::vector<float>>
+    plotFilterMagnitudeResponse(sst::filtersplusplus::FilterModel model,
+                                sst::filtersplusplus::ModelConfig config, float pitch, float res,
+                                float extra1, float extra2, float extra3,
+                                const FilterPlotParameters &params = {})
+    {
+        auto lt = sst::filtersplusplus::Filter::getLegacyTypeFor(model, config);
+        if (lt.has_value())
+            return plotFilterMagnitudeResponse(lt->first, lt->second, pitch, res, extra1, extra2,
+                                               extra3, params);
+
+        return {};
     }
 
     std::pair<std::vector<float>, std::vector<float>>

--- a/include/sst/filters++/api.h
+++ b/include/sst/filters++/api.h
@@ -18,6 +18,7 @@
 
 #include <vector>
 #include <cmath>
+#include <optional>
 
 #include "sst/basic-blocks/simd/setup.h"
 
@@ -290,6 +291,15 @@ struct Filter
      * Resets the filter registers; leaves the rest of the state intact
      */
     void reset() { payload.reset(); }
+
+    /**
+     * This API connects us to the legacy enum types for a given model
+     */
+    using legacyType_t = std::pair<sst::filters::FilterType, sst::filters::FilterSubType>;
+    static std::optional<legacyType_t> getLegacyTypeFor(const FilterModel &m, const ModelConfig &c)
+    {
+        return details::FilterPayload::resolveLegacyTypeFor(m, c);
+    }
 
   protected:
     details::FilterPayload payload;


### PR DESCRIPTION
1. to api.h add a static getLegacyType api so you can resolve a config without a full instance

2. use that to expand the Filterplotter so it can work off of model and model config not just old types