### PR TITLE
Add support for extra being 0...1 or bipolar

### DIFF
--- a/include/sst/filters++/api.h
+++ b/include/sst/filters++/api.h
@@ -164,6 +164,14 @@ struct Filter
     [[nodiscard]] static int coefficientsExtraCount(FilterModel model, const ModelConfig &c);
 
     /**
+     * Extra arguments are normalized to either be 0..1 (like pole mixing on a 4 pole filter)
+     * or -1..1 (like shelf cut/boost on a low shelf). But you need to know which is which!
+     * This returns true for bipolar (-1..1) and false for unipolar (0..1)
+     */
+    [[nodiscard]] static bool coefficientsExtraIsBipolar(FilterModel model, const ModelConfig &c,
+                                                         int coeff);
+
+    /**
      * Get a list of the available models supported by the API
      */
     static std::vector<FilterModel> availableModels();

--- a/include/sst/filters++/details/filter_impl.h
+++ b/include/sst/filters++/details/filter_impl.h
@@ -81,6 +81,30 @@ inline int Filter::coefficientsExtraCount(FilterModel model, const ModelConfig &
     return 0;
 }
 
+inline bool Filter::coefficientsExtraIsBipolar(FilterModel model, const ModelConfig &config,
+                                               int coeff)
+{
+    switch (model)
+    {
+    case FilterModel::Comb:
+        if (config.st == Slope::Comb_Bipolar_ContinuousMix)
+            return true;
+        break;
+    case FilterModel::CytomicSVF:
+    {
+        if (config.pt == Passband::Bell || config.pt == Passband::LowShelf ||
+            config.pt == Passband::HighShelf)
+        {
+            return true;
+        }
+        break;
+    }
+    default:
+        return false;
+    }
+    return false;
+}
+
 inline void Filter::makeCoefficients(int voice, float cutoff, float resonance, float extra,
                                      float extra2, float extra3)
 {

--- a/include/sst/filters/CytomicSVFQuadForm.h
+++ b/include/sst/filters/CytomicSVFQuadForm.h
@@ -41,7 +41,7 @@ struct Reg
 template <typename TuningProvider>
 void makeCoefficients(FilterCoefficientMaker<TuningProvider> *cm, float freq, float res,
                       int subtype, float sampleRate, float sampleRateInv, TuningProvider *provider,
-                      float bellShelfAmp)
+                      float bellShelfAmpPM1)
 {
     float lC[n_cm_coeffs]{};
 
@@ -57,6 +57,7 @@ void makeCoefficients(FilterCoefficientMaker<TuningProvider> *cm, float freq, fl
     auto g = sst::basic_blocks::dsp::fasttan(M_PI * conorm);
     auto k = 2.0 - 2 * res;
 
+    auto bellShelfAmp = bellShelfAmpPM1 + 1; // since the input is bipolar -1..1
     if (subtype == st_cytomic_bell)
     {
         bellShelfAmp = std::max(bellShelfAmp, 0.001f);
@@ -103,7 +104,7 @@ void makeCoefficients(FilterCoefficientMaker<TuningProvider> *cm, float freq, fl
         break;
     case st_cytomic_bell:
     {
-        auto A = std::clamp(bellShelfAmp, 0.001f, 0.999f);
+        auto A = std::clamp(bellShelfAmp, 0.001f, 1.999f);
         lC[Coeff::m0] = 1.0;
         lC[Coeff::m1] = k * (A * A - 1);
         lC[Coeff::m2] = 0;
@@ -111,7 +112,7 @@ void makeCoefficients(FilterCoefficientMaker<TuningProvider> *cm, float freq, fl
     break;
     case st_cytomic_lowshelf:
     {
-        auto A = std::clamp(bellShelfAmp, 0.001f, 0.999f);
+        auto A = std::clamp(bellShelfAmp, 0.001f, 1.999f);
         lC[Coeff::m0] = 1.0;
         lC[Coeff::m1] = k * (A - 1);
         lC[Coeff::m2] = A * A - 1;
@@ -119,7 +120,7 @@ void makeCoefficients(FilterCoefficientMaker<TuningProvider> *cm, float freq, fl
     break;
     case st_cytomic_highshelf:
     {
-        auto A = std::clamp(bellShelfAmp, 0.001f, 0.999f);
+        auto A = std::clamp(bellShelfAmp, 0.001f, 1.999f);
         lC[Coeff::m0] = A * A;
         lC[Coeff::m1] = A * k * (1 - A);
         lC[Coeff::m2] = 1 - A * A;


### PR DESCRIPTION
- comb bipolar and shelf/bell are -1..1 rather than 0..1 extra
- adjust cytomic quad to match the spec
- adjust filter api to allow discovery thereof