### PR TITLE
Add a Linkwitz-Riley LR4 stereo crossover filter

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -32,20 +32,20 @@ jobs:
             name: mac-arm-nonative
             cmakeArgs: -DCMAKE_OSX_ARCHITECTURES=arm64 -DSST_BASIC_BLOCKS_SIMD_OMIT_NATIVE_ALIASES=TRUE
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-x86
             runTest: true
             testExe:  build/tests/Release/sst-filters-tests.exe
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-arm64
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64 -DCMAKE_SYSTEM_VERSION=10
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-arm64ec
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64ec -DCMAKE_SYSTEM_VERSION=10
 
-          - os: windows-latest
+          - os: windows-2022
             name: win-arm64-non-native
             cmakeArgs: -G"Visual Studio 17 2022" -A arm64 -DCMAKE_SYSTEM_VERSION=10 -DSST_BASIC_BLOCKS_SIMD_OMIT_NATIVE_ALIASES=TRUE
 

--- a/include/sst/filters/CytomicSVF.h
+++ b/include/sst/filters/CytomicSVF.h
@@ -27,6 +27,7 @@
 #define INCLUDE_SST_FILTERS_CYTOMICSVF_H
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cassert>
 #include <complex>
@@ -140,6 +141,30 @@ struct CytomicSVF
         setCoeffPostGK(mode, bellShelfAmp);
     }
 
+    /*
+     * As above but with a distinct mode per SIMD lane. freq / res / bellShelfAmp
+     * are shared across the four lanes; only the output mixing (and the Bell k
+     * remap) varies per lane. Handy when you want, say, lowpass and highpass
+     * running in parallel off the same cutoff (see LinkwitzRiley.h).
+     */
+    void setCoeff(std::array<Mode, 4> mode, float freq, float res, float srInv,
+                  float bellShelfAmp = 1.f)
+    {
+        auto conorm = std::clamp(freq * srInv, 0.f, 0.499f); // stable until nyquist
+        res = std::clamp(res, 0.f, 0.98f);
+        bellShelfAmp = std::max(bellShelfAmp, 0.001f);
+
+        g = SETALL(sst::basic_blocks::dsp::fasttan(M_PI * conorm));
+
+        auto kbase = 2.0f - 2.f * res;
+        float kl alignas(16)[4];
+        for (int i = 0; i < 4; ++i)
+            kl[i] = (mode[i] == Mode::Bell) ? kbase / bellShelfAmp : kbase;
+        k = SIMD_MM(set_ps)(kl[3], kl[2], kl[1], kl[0]);
+
+        setCoeffPostGK(mode, SETALL(bellShelfAmp));
+    }
+
     // quad version for use in the shepard phaser. Somewhat simplified to save a couple cycles
     // but easy to expand to match the mono/stereo versions if we ever want to.
     void setCoeffQuadBandpass(float *freq, float res, float srInv)
@@ -228,6 +253,84 @@ struct CytomicSVF
             m2 = SIMD_MM(setzero_ps)();
             break;
         }
+    }
+
+    // Per-lane mode companion to the single-mode setCoeffPostGK above. g/k must
+    // already be set (k may differ per lane, e.g. the Bell remap). Only the
+    // m0/m1/m2 output mix varies between lanes; a1/a2/a3 follow from g/k as usual.
+    void setCoeffPostGK(std::array<Mode, 4> mode, SIMD_M128 bellShelfSSE)
+    {
+        gk = ADD(g, k);
+        a1 = DIV(oneSSE, ADD(oneSSE, MUL(g, gk)));
+        a2 = MUL(g, a1);
+        a3 = MUL(g, a2);
+
+        float kl alignas(16)[4], al alignas(16)[4];
+        SIMD_MM(store_ps)(kl, k);
+        SIMD_MM(store_ps)(al, bellShelfSSE);
+
+        float l0[4], l1[4], l2[4];
+        for (int i = 0; i < 4; ++i)
+        {
+            auto kv = kl[i];
+            auto A = al[i];
+            switch (mode[i])
+            {
+            case Mode::Lowpass:
+                l0[i] = 0;
+                l1[i] = 0;
+                l2[i] = 1;
+                break;
+            case Mode::Bandpass:
+                l0[i] = 0;
+                l1[i] = 1;
+                l2[i] = 0;
+                break;
+            case Mode::Highpass:
+                l0[i] = 1;
+                l1[i] = -kv;
+                l2[i] = -1;
+                break;
+            case Mode::Notch:
+                l0[i] = 1;
+                l1[i] = -kv;
+                l2[i] = 0;
+                break;
+            case Mode::Peak:
+                l0[i] = 1;
+                l1[i] = -kv;
+                l2[i] = -2;
+                break;
+            case Mode::Allpass:
+                l0[i] = 1;
+                l1[i] = -2 * kv;
+                l2[i] = 0;
+                break;
+            case Mode::Bell:
+                l0[i] = 1;
+                l1[i] = kv * (A * A - 1);
+                l2[i] = 0;
+                break;
+            case Mode::LowShelf:
+                l0[i] = 1;
+                l1[i] = kv * (A - 1);
+                l2[i] = A * A - 1;
+                break;
+            case Mode::HighShelf:
+                l0[i] = A * A;
+                l1[i] = A * kv * (1 - A);
+                l2[i] = 1 - A * A;
+                break;
+            default:
+                l0[i] = 0;
+                l1[i] = 0;
+                l2[i] = 0;
+                break;
+            }
+        }
+        m0 = SIMD_MM(set_ps)(l0[3], l0[2], l0[1], l0[0]);
+        m1 = SIMD_MM(set_ps)(l1[3], l1[2], l1[1], l1[0]);
+        m2 = SIMD_MM(set_ps)(l2[3], l2[2], l2[1], l2[0]);
     }
 
     void fetchCoeffs(const CytomicSVF &that)

--- a/include/sst/filters/LinkwitzRiley.h
+++ b/include/sst/filters/LinkwitzRiley.h
@@ -1,0 +1,177 @@
+/*
+ * sst-filters - A header-only collection of SIMD filter
+ * implementations by the Surge Synth Team
+ *
+ * Copyright 2019-2025, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-filters is released under the Gnu General Public Licens
+ * version 3 or later. Some of the filters in this package
+ * originated in the version of Surge open sourced in 2018.
+ *
+ * All source in sst-filters available at
+ * https://github.com/surge-synthesizer/sst-filters
+ */
+
+#ifndef INCLUDE_SST_FILTERS_LINKWITZRILEY_H
+#define INCLUDE_SST_FILTERS_LINKWITZRILEY_H
+
+#include <array>
+
+#include "CytomicSVF.h"
+
+/*
+ * A 4th order Linkwitz-Riley (LR4) stereo crossover built on the CytomicSVF.
+ *
+ * An LR4 crossover splits a signal into a low band and a high band such that
+ * the two bands sum back to the input with a flat magnitude response (an
+ * allpass). The bands stay in phase at every frequency and are each down 6 dB
+ * at the crossover, so nothing is boosted or notched when you recombine them.
+ *
+ * An LR4 section is a cascade of two identical 2nd order Butterworth sections
+ * (Q = 1/sqrt(2)). The CytomicSVF maps its resonance to k = 2 - 2*res with
+ * Q = 1/k, so a Butterworth section needs k = sqrt(2), i.e.
+ *
+ *     2 - 2*res = sqrt(2)   =>   res = (2 - sqrt(2)) / 2 = 1 - 1/sqrt(2)
+ *
+ * The neat part is the SIMD packing. We load a stereo sample into one register
+ * as [L, R, L, R] and assign the two lower lanes the lowpass mode and the two
+ * upper lanes the highpass mode, so a single SVF step produces both bands of
+ * both channels at once. Two such steps cascaded give LR4. Both cascade stages
+ * use *identical* coefficients (same cutoff, same Butterworth res, same modes)
+ * so we compute them once and share them via fetchCoeffs. Within a stage the
+ * lowpass and highpass lanes share g/k/a1/a2/a3 and differ only in the m0/m1/m2
+ * output mix, so there is no duplicated coefficient math at all.
+ */
+
+namespace sst::filters
+{
+
+struct LinkwitzRileyLR4Crossover
+{
+    // Two cascaded Butterworth sections make up the LR4. They are coefficient
+    // clones of each other; only their integrator state differs.
+    CytomicSVF stage1, stage2;
+
+    // res that turns a CytomicSVF section into a Butterworth (Q = 1/sqrt(2))
+    // section: 1 - 1/sqrt(2). Spelled out so we do not lean on M_SQRT1_2.
+    static constexpr float butterworthRes{0.2928932188134524f};
+
+    // [L, R, L, R] -> lowpass on lanes 0,1 and highpass on lanes 2,3
+    static constexpr std::array<CytomicSVF::Mode, 4> crossoverModes{
+        CytomicSVF::Mode::Lowpass, CytomicSVF::Mode::Lowpass, CytomicSVF::Mode::Highpass,
+        CytomicSVF::Mode::Highpass};
+
+    void init()
+    {
+        stage1.init();
+        stage2.init();
+    }
+
+    /*
+     * Set the crossover frequency directly (no smoothing). Both cascade stages
+     * receive the same coefficients; stage2 fetches them rather than recomputing.
+     */
+    void setCoeff(float crossoverFreq, float srInv)
+    {
+        stage1.setCoeff(crossoverModes, crossoverFreq, butterworthRes, srInv);
+        stage2.fetchCoeffs(stage1);
+    }
+
+    /*
+     * One stereo sample in, both bands of both channels out. The lowpass and
+     * highpass bands are in phase, so low + high reconstructs the input.
+     */
+    void step(float L, float R, float &lowL, float &lowR, float &highL, float &highR)
+    {
+        auto vin = SIMD_MM(set_ps)(R, L, R, L); // [L, R, L, R]
+        auto s1 = CytomicSVF::stepSSE(stage1, vin);
+        auto s2 = CytomicSVF::stepSSE(stage2, s1);
+
+        float r4 alignas(16)[4];
+        SIMD_MM(store_ps)(r4, s2);
+        lowL = r4[0];
+        lowR = r4[1];
+        highL = r4[2];
+        highR = r4[3];
+    }
+
+    /*
+     * Block processing with per-sample coefficient smoothing across the block.
+     * Only g/a1/a2/a3 move as the cutoff glides; the modes (and hence k and the
+     * m mix) are fixed, so we smooth a1/a2/a3 and keep both stages in lockstep.
+     */
+#define LR_ADD(a, b) SIMD_MM(add_ps)(a, b)
+#define LR_SUB(a, b) SIMD_MM(sub_ps)(a, b)
+#define LR_MUL(a, b) SIMD_MM(mul_ps)(a, b)
+
+    SIMD_M128 da1{SIMD_MM(setzero_ps)()}, da2{SIMD_MM(setzero_ps)()}, da3{SIMD_MM(setzero_ps)()};
+    bool firstBlock{true};
+
+    template <int blockSize> void setCoeffForBlock(float crossoverFreq, float srInv)
+    {
+        auto a1p = stage1.a1;
+        auto a2p = stage1.a2;
+        auto a3p = stage1.a3;
+
+        setCoeff(crossoverFreq, srInv);
+
+        if (firstBlock)
+        {
+            a1p = stage1.a1;
+            a2p = stage1.a2;
+            a3p = stage1.a3;
+            firstBlock = false;
+        }
+
+        static constexpr float obsf = 1.f / blockSize;
+        auto obs = SIMD_MM(set1_ps)(obsf);
+
+        da1 = LR_MUL(LR_SUB(stage1.a1, a1p), obs);
+        da2 = LR_MUL(LR_SUB(stage1.a2, a2p), obs);
+        da3 = LR_MUL(LR_SUB(stage1.a3, a3p), obs);
+
+        setStageA(a1p, a2p, a3p);
+    }
+
+    template <int blockSize> void retainCoeffForBlock()
+    {
+        da1 = SIMD_MM(setzero_ps)();
+        da2 = SIMD_MM(setzero_ps)();
+        da3 = SIMD_MM(setzero_ps)();
+    }
+
+    void processBlockStep(float L, float R, float &lowL, float &lowR, float &highL, float &highR)
+    {
+        step(L, R, lowL, lowR, highL, highR);
+        setStageA(LR_ADD(stage1.a1, da1), LR_ADD(stage1.a2, da2), LR_ADD(stage1.a3, da3));
+    }
+
+    template <int blockSize>
+    void processBlock(const float *const inL, const float *const inR, float *lowL, float *lowR,
+                      float *highL, float *highR)
+    {
+        for (int i = 0; i < blockSize; ++i)
+            processBlockStep(inL[i], inR[i], lowL[i], lowR[i], highL[i], highR[i]);
+    }
+
+  private:
+    // keep the two stages' a-coefficients identical
+    void setStageA(SIMD_M128 a1, SIMD_M128 a2, SIMD_M128 a3)
+    {
+        stage1.a1 = a1;
+        stage1.a2 = a2;
+        stage1.a3 = a3;
+        stage2.a1 = a1;
+        stage2.a2 = a2;
+        stage2.a3 = a3;
+    }
+
+#undef LR_ADD
+#undef LR_SUB
+#undef LR_MUL
+};
+
+} // namespace sst::filters
+
+#endif // INCLUDE_SST_FILTERS_LINKWITZRILEY_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(sst-filters-tests
         DiodeLadderTest.cpp
         FastTiltNoiseFilterTest.cpp
         K35FilterTest.cpp
+        LinkwitzRileyTest.cpp
         HalfRateTest.cpp
         OBXDFilterTest.cpp
         ResonanceWarpTest.cpp

--- a/tests/LinkwitzRileyTest.cpp
+++ b/tests/LinkwitzRileyTest.cpp
@@ -1,0 +1,179 @@
+/*
+ * sst-filters - A header-only collection of SIMD filter
+ * implementations by the Surge Synth Team
+ *
+ * Copyright 2019-2025, various authors, as described in the GitHub
+ * transaction log.
+ *
+ * sst-filters is released under the Gnu General Public Licens
+ * version 3 or later. Some of the filters in this package
+ * originated in the version of Surge open sourced in 2018.
+ *
+ * All source in sst-filters available at
+ * https://github.com/surge-synthesizer/sst-filters
+ */
+
+#include "catch2/catch2.hpp"
+#include "sst/filters/LinkwitzRiley.h"
+
+#include <cmath>
+
+namespace
+{
+constexpr double sr{48000}, sri{1.0 / sr};
+
+struct Bands
+{
+    double in, low, high, sum; // RMS of input, low band, high band, and (low + high)
+};
+
+/*
+ * Drive the crossover with a stereo tone (same signal both channels) and return
+ * the steady-state RMS of the input, the two bands, and their sum. We warm up
+ * for 50 ms then integrate over a whole number of cycles so the RMS of a pure
+ * tone is exact, which keeps the reconstruction check tight.
+ */
+Bands measure(float crossoverFreq, float toneFreq)
+{
+    sst::filters::LinkwitzRileyLR4Crossover lr;
+    lr.setCoeff(crossoverFreq, sri);
+    lr.init();
+
+    int warm = (int)(0.05 * sr);
+    int cycles = 80;
+    int meas = (int)std::round(cycles * sr / toneFreq);
+
+    double inSq{0}, lowSq{0}, highSq{0}, sumSq{0};
+    for (int i = 0; i < warm + meas; ++i)
+    {
+        auto t = i * sri;
+        float s = (float)std::sin(2 * M_PI * toneFreq * t);
+        float lL, lR, hL, hR;
+        lr.step(s, s, lL, lR, hL, hR);
+
+        if (i >= warm)
+        {
+            float sum = lL + hL;
+            inSq += (double)s * s;
+            lowSq += (double)lL * lL;
+            highSq += (double)hL * hL;
+            sumSq += (double)sum * sum;
+        }
+    }
+    return {std::sqrt(inSq / meas), std::sqrt(lowSq / meas), std::sqrt(highSq / meas),
+            std::sqrt(sumSq / meas)};
+}
+} // namespace
+
+TEST_CASE("Linkwitz-Riley LR4 Crossover")
+{
+    float xover = 1000.f;
+
+    SECTION("Bands sum to a flat (allpass) magnitude at every frequency")
+    {
+        // The defining LR4 property: the two bands are in phase everywhere, so
+        // low + high reconstructs the input with no boost or notch. A flat
+        // magnitude sum across the spectrum is exactly the "constant phase"
+        // (phase-coherent) behaviour we are after.
+        for (float f : {20.f, 40.f, 80.f, 160.f, 320.f, 640.f, 1000.f, 1280.f, 2560.f, 5120.f,
+                        10240.f, 18000.f})
+        {
+            auto b = measure(xover, f);
+            INFO("tone " << f << " Hz: in=" << b.in << " sum=" << b.sum
+                         << " ratio=" << b.sum / b.in);
+            REQUIRE(b.sum / b.in == Approx(1.0).margin(0.01));
+        }
+    }
+
+    SECTION("Each band is -6 dB at the crossover")
+    {
+        auto b = measure(xover, xover);
+        REQUIRE(b.low / b.in == Approx(0.5).margin(0.02));
+        REQUIRE(b.high / b.in == Approx(0.5).margin(0.02));
+    }
+
+    SECTION("Low band passes lows and blocks highs; high band the reverse")
+    {
+        auto below = measure(xover, xover / 10); // 100 Hz, a decade below
+        REQUIRE(below.low / below.in > 0.95f);
+        REQUIRE(below.high / below.in < 0.05f);
+
+        auto above = measure(xover, xover * 10); // 10 kHz, a decade above
+        REQUIRE(above.high / above.in > 0.95f);
+        REQUIRE(above.low / above.in < 0.05f);
+    }
+}
+
+TEST_CASE("Linkwitz-Riley reconstructs each stereo channel independently")
+{
+    // Different tone per channel proves the [L, R, L, R] lane packing keeps the
+    // two channels separate while still reconstructing each one.
+    sst::filters::LinkwitzRileyLR4Crossover lr;
+    lr.setCoeff(800.f, sri);
+    lr.init();
+
+    float fL = 200.f, fR = 4000.f;
+    int n = (int)(0.3 * sr);
+    int warm = (int)(0.05 * sr);
+
+    double errL{0}, errR{0}, refL{0}, refR{0};
+    for (int i = 0; i < n; ++i)
+    {
+        auto t = i * sri;
+        float l = (float)std::sin(2 * M_PI * fL * t);
+        float r = (float)std::sin(2 * M_PI * fR * t);
+        float lL, lR, hL, hR;
+        lr.step(l, r, lL, lR, hL, hR);
+
+        if (i >= warm)
+        {
+            // each channel's bands recombine to that channel only
+            errL += (double)(lL + hL) * (lL + hL);
+            errR += (double)(lR + hR) * (lR + hR);
+            refL += (double)l * l;
+            refR += (double)r * r;
+        }
+    }
+    // reconstructed energy matches the original per-channel energy (allpass)
+    REQUIRE(std::sqrt(errL / refL) == Approx(1.0).margin(0.01));
+    REQUIRE(std::sqrt(errR / refR) == Approx(1.0).margin(0.01));
+}
+
+TEST_CASE("Linkwitz-Riley block processing matches per-sample stepping")
+{
+    // At a constant cutoff the smoothing deltas are zero, so the block path must
+    // reproduce the per-sample step path exactly.
+    static constexpr int bs = 64;
+    float xover = 1200.f;
+
+    sst::filters::LinkwitzRileyLR4Crossover perSample, block;
+    perSample.setCoeff(xover, sri);
+    perSample.init();
+    block.init();
+
+    float inL[bs], inR[bs];
+    float blL[bs], blR[bs], bhL[bs], bhR[bs];
+
+    for (int blk = 0; blk < 8; ++blk)
+    {
+        for (int i = 0; i < bs; ++i)
+        {
+            auto t = (blk * bs + i) * sri;
+            inL[i] = (float)std::sin(2 * M_PI * 300.f * t);
+            inR[i] = (float)std::sin(2 * M_PI * 2500.f * t);
+        }
+
+        block.setCoeffForBlock<bs>(xover, sri);
+        block.processBlock<bs>(inL, inR, blL, blR, bhL, bhR);
+
+        for (int i = 0; i < bs; ++i)
+        {
+            float lL, lR, hL, hR;
+            perSample.step(inL[i], inR[i], lL, lR, hL, hR);
+            REQUIRE(blL[i] == Approx(lL));
+            REQUIRE(blR[i] == Approx(lR));
+            REQUIRE(bhL[i] == Approx(hL));
+            REQUIRE(bhR[i] == Approx(hR));
+        }
+    }
+}


### PR DESCRIPTION
Adds sst::filters::LinkwitzRileyLR4Crossover built on the CytomicSVF, splitting a stereo signal into phase-coherent low and high bands that reconstruct to a flat magnitude. Also adds a per-lane mode variant of CytomicSVF::setCoeff/setCoeffPostGK so the crossover can run lowpass and highpass in parallel within one SIMD step.

Assisted-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>